### PR TITLE
Fix ssl generation

### DIFF
--- a/crits_web/Dockerfile
+++ b/crits_web/Dockerfile
@@ -78,13 +78,19 @@ RUN rm /etc/apache2/sites-enabled/* && \
 WORKDIR /tmp
 RUN openssl req -nodes -newkey rsa:2048 -keyout new.cert.key -out new.cert.csr -subj "/C=US/ST=Oregon/L=Beaverton/O=Security/OU=Security/CN=crits.example.com" && \
   openssl x509 -in new.cert.csr -out new.cert.cert -req -signkey new.cert.key -days 1825 && \
-  cp new.cert.cert /etc/ssl/certs/crits.crt && \
-  cp new.cert.key /etc/ssl/private/crits.plain.key && \
+  # Place the certs inside the crits directory, so they can be overridden with a volume
+  mkdir -p /data/crits/ssl/ && \
+  cp new.cert.cert /data/crits/ssl/crits.crt && \
+  cp new.cert.key /data/crits/ssl/crits.plain.key && \
+  # Create sym-links to keys, to preserve http config
+  ln -s /data/crits/ssl/crits.crt /etc/ssl/certs/crits.crt && \
+  ln -s /data/crits/ssl/crits.plain.key /etc/ssl/private/crits.plain.key && \
   a2enmod ssl && \
   echo "export LANG=en_US.UTF-8" >> /etc/apache2/envvars
 
 
 VOLUME ["/data/crits"]
+VOLUME ["/data/crits/ssl"]
 
 EXPOSE 443
 

--- a/initializeDockerContainers.sh
+++ b/initializeDockerContainers.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "Spinning initializer container for $user/$email"
+sleep 5 # Required to prevent spinning from happening before mongo is ready.  Not sure why the mongo container doesn't validate that
+docker run --link crits_mongo:crits_mongo -t crits_web /data/crits/initializeMongo.sh -u $user -e $email
+echo "Done initializing"

--- a/startDockerContainers.sh
+++ b/startDockerContainers.sh
@@ -1,52 +1,8 @@
 #!/bin/bash
 
-# A POSIX variable
-OPTIND=1         # Reset in case getopts has been used previously in the shell.
-
-# Initialize our own variables:
-initialize=false
-
-usage () {
-  echo "Usage:
-  -i: Initialize mongo container (Default false)"
-}
-
-while getopts ":h?iu:e:" opt; do
-  case "$opt" in
-    h|\?)
-    usage
-    exit 0
-    ;;
-    i)  initialize=true;;
-    u)  user=$OPTARG;;
-    e)  email=$OPTARG
-  esac
-done
-
-shift $((OPTIND-1))
-
-# Verify user/email specified if initializing
-if $initialize && ( [ -z "$user" ] || [ -z "$email" ] )
-  then
-  usage
-  >&2 echo "Both User (-u) and Email (-e) are required when initializing"
-  exit 1
-fi
-
-
 # Start the crits_mongo server
 echo "Starting crits_mongo"
 docker rm crits_mongo &>/dev/null; docker run -d -h crits_mongo --name crits_mongo -v /data/db:/data/db -t crits_mongo
-
-# Initialize, if specified
-if $initialize
-  then
-  echo "Spinning initializer container for $user/$email"
-  sleep 5 # Required to prevent spinning from happening before mongo is ready.  Not sure why the mongo container doesn't validate that
-  docker run --link crits_mongo:crits_mongo -t crits_web /data/crits/initializeMongo.sh -u $user -e $email
-  echo "Done initializing"
-fi
-
 
 # Start the crits_web server
 echo "Starting crits_web"


### PR DESCRIPTION
The ssl certificate/key that are generated during the build process are
sufficient for initial testing, but production use requires permanent
certificates/keys.

This modification places the cert/key into /data/crits/ssl, and creates
the necessary symbolic links so the apache can find them.

In order to override the default certs, create the certs in a  directory
with names:
    - crits.crt
    - crits.plain.key
During spinup of crits_web, specify the volume to reference the volume:

```
docker run ... -v [directory where certs are stored]:/data/crits/ssl:ro ...
```
